### PR TITLE
Fix incorrect gem license name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Add `ruby-3.3` to CI
 * Add `dependabot` check for `GitHub Actions`
 
+### Fixes
+
+* Fix incorrect gem license name
+
 ### Changes
 
 * Drop support of `ruby-2.7`, since it's EOLed

--- a/onlyoffice_language_helper.gemspec
+++ b/onlyoffice_language_helper.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
   s.files = Dir['lib/**/*']
-  s.license = 'AGPL-3.0'
+  s.license = 'AGPL-3.0-or-later'
   s.add_runtime_dependency('detect_language', '~> 1')
   s.add_runtime_dependency('ffi-hunspell', '~> 0')
   s.add_runtime_dependency('httparty', '>= 0.10.0')


### PR DESCRIPTION
This cause warnings on `gem build`