### PR TITLE
Fix gem build warning about `httparty` gem version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Fix incorrect gem license name
 * Fix warning about homepage gem metadata
+* Fix gem build warning about `httparty` gem version
 
 ### Changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     onlyoffice_language_helper (0.5.0)
       detect_language (~> 1)
       ffi-hunspell (~> 0)
-      httparty (>= 0.10.0)
+      httparty (~> 0.10, >= 0.10.0)
       onlyoffice_file_helper (< 3)
       onlyoffice_logger_helper (~> 1)
       whatlanguage (~> 1)

--- a/onlyoffice_language_helper.gemspec
+++ b/onlyoffice_language_helper.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.license = 'AGPL-3.0-or-later'
   s.add_runtime_dependency('detect_language', '~> 1')
   s.add_runtime_dependency('ffi-hunspell', '~> 0')
-  s.add_runtime_dependency('httparty', '>= 0.10.0')
+  s.add_runtime_dependency('httparty', '~> 0.10', '>= 0.10.0')
   s.add_runtime_dependency('onlyoffice_file_helper', '< 3')
   s.add_runtime_dependency('onlyoffice_logger_helper', '~> 1')
   s.add_runtime_dependency('whatlanguage', '~> 1')


### PR DESCRIPTION
The warning was:
```
WARNING:  open-ended dependency on httparty (>= 0.10.0) is not recommended
  if httparty is semantically versioned, use:
    add_runtime_dependency "httparty", "~> 0.10", ">= 0.10.0"
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
```